### PR TITLE
 Add overloads for using existing IO objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@
 
 ## Interface
 
-* `StumpyPNG.read(path) : Canvas` read a PNG image file
-* `StumpyPNG.write(canvas, path, bit_depth: 16, color_type: :grayscale)` saves a canvas as a PNG image file
+* `StumpyPNG.read(path : String) : Canvas` read a PNG image file from a path
+* `StumpyPNG.read(io : IO) : Canvas` read a PNG image file from any IO object
+* `StumpyPNG.write(canvas, path : String, bit_depth: 16, color_type: :rgb_alpha)` save a canvas as a PNG image file
+* `StumpyPNG.write(canvas, io : IO, bit_depth: 16, color_type: :rgb_alpha)` write a canvas as PNG data to any IO object
   * `bit_depth` is optional, valid values are `8` and `16`(default)
   * `color_type` is optional, valid values are `:grayscale`, `:grayscale_alpha`, `:rgb` and `:rgb_alpha`(default)
 * `StumpyPNG::PNG`, helper class to store some state while parsing PNG files

--- a/spec/api_spec.cr
+++ b/spec/api_spec.cr
@@ -1,0 +1,24 @@
+require "minitest/autorun"
+require "../src/stumpy_png"
+
+module StumpyPNG
+  class StumpyPNGAPITest < Minitest::Test
+    def test_path_read_write
+      canvas = StumpyPNG.read("./spec/png_suite/basic_formats/basn0g01.png")
+      StumpyPNG.write(canvas, "/tmp/test.png")
+    end
+
+    def test_io_read_write
+      in_io = IO::Memory.new
+      File.open("./spec/png_suite/basic_formats/basn0g01.png", "rb") do |file|
+        IO.copy(file, in_io)
+      end
+      in_io.rewind
+      
+      canvas = StumpyPNG.read(in_io)
+
+      out_io = IO::Memory.new
+      StumpyPNG.write(canvas, out_io)
+    end
+  end
+end


### PR DESCRIPTION
Solves #17. As outlined in the issue, this PR allows you to use any `IO` to read from or write to! I also went ahead and added tests for the new parts, and added them to the readme.

This PR *does* change the order of errors a bit - now, errors on opening the files will be raised before validation errors on `bit_depth` and `color_type`. If that order matters to you, say the word and I'll break the business logic out into a private method and move the validation into both of the two public ones.

I haven't rebuilt the documentation, as that made a bunch of changes I don't know if you want. You can just run `crystal docs --output=doc` to build it, though.

If you've got any questions or concerns, let me know and I'll do my best to address them!