### PR TITLE
Fix 8 bit depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
  dependencies:
    stumpy_png:
      github: stumpycr/stumpy_png
-     version: "~> 4.4"
+     version: "~> 4.4.1"
  ...
  ```
 3. `shards install`

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: stumpy_png
-version: 4.4.0
+version: 4.4.1
 
 authors:
   - Leon Rische <leon.rische@me.com>

--- a/src/stumpy_png.cr
+++ b/src/stumpy_png.cr
@@ -120,10 +120,12 @@ module StumpyPNG
     else
       buffer = Bytes.new(1 + canvas.width * 4)
       canvas.each_row do |col|
-        col.each_with_index(1) do |pixel, i|
+        i = 1
+        col.each do |pixel|
           {pixel.r, pixel.g, pixel.b, pixel.a}.each do |value|
             # TODO: use IO::ByteFormat::BigEndian.encode(value, buffer_ptr) once 0.20.1 is out
             buffer[i] = (value >> 8).to_u8
+            i += 1
           end
         end
         output.write(buffer)
@@ -147,10 +149,12 @@ module StumpyPNG
     else
       buffer = Bytes.new(1 + canvas.width * 3)
       canvas.each_row do |col|
-        col.each_with_index(1) do |pixel, i|
+        i = 1
+        col.each do |pixel|
           {pixel.r, pixel.g, pixel.b}.each do |value|
             # TODO: use IO::ByteFormat::BigEndian.encode(value, buffer_ptr) once 0.20.1 is out
             buffer[i] = (value >> 8).to_u8
+            i += 1
           end
         end
         output.write(buffer)
@@ -175,11 +179,13 @@ module StumpyPNG
     else
       buffer = Bytes.new(1 + canvas.width * 2)
       canvas.each_row do |col|
-        col.each_with_index(1) do |pixel, i|
+        i = 1
+        col.each do |pixel|
           gray = (pixel.r.to_u32 + pixel.g + pixel.b) / 3
           {gray, pixel.a}.each do |value|
             # TODO: use IO::ByteFormat::BigEndian.encode(value, buffer_ptr) once 0.20.1 is out
             buffer[i] = (value >> 8).to_u8
+            i += 1
           end
         end
         output.write(buffer)
@@ -202,9 +208,11 @@ module StumpyPNG
     else
       buffer = Bytes.new(1 + canvas.width * 1)
       canvas.each_row do |col|
-        col.each_with_index(1) do |pixel, i|
+        i = 1
+        col.each do |pixel|
           gray = (pixel.r.to_u32 + pixel.g + pixel.b) / 3
           buffer[i] = (gray >> 8).to_u8
+          i += 1
         end
         output.write(buffer)
       end


### PR DESCRIPTION
Fixes #20 

I wanted to improve the readability of the code a bit in [#19](https://github.com/stumpycr/stumpy_png/pull/19/files#diff-1faabda48ccb57e7fd49423d3c44c58a) by using `each_with_index(1)` but for some reason this causes weird output like this:
![circle_test](https://user-images.githubusercontent.com/35064754/43281650-93db605a-9114-11e8-91ca-bc57993562c3.png)

But this fixes it by defining `i` manually again.
![circle_test](https://user-images.githubusercontent.com/35064754/43281575-57b38bde-9114-11e8-8239-7b591ea055e3.png)


