### PR TITLE
Fix warning about int literal

### DIFF
--- a/src/stumpy_png.cr
+++ b/src/stumpy_png.cr
@@ -10,7 +10,7 @@ module StumpyPNG
 
   extend self
 
-  HEADER = 0x89504e470d0a1a0a
+  HEADER = 0x89504e470d0a1a0a_u64
 
   WRITE_BIT_DEPTHS  = {8, 16}
   WRITE_COLOR_TYPES = {


### PR DESCRIPTION
```
In src/stumpy_png.cr:13:12

 13 | HEADER = 0x89504e470d0a1a0a
               ^
Warning: 0x89504e470d0a1a0a doesn't fit in an Int64, try using the suffix u64 or i128
```

Resolves #42